### PR TITLE
Support for RDF-star term maps. Necessary for Ontop's RDF-star support.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ allprojects {
     apply plugin: 'maven'
 
     group = 'eu.optique-project'
-    version = '0.6.0'
+    version = '0.6.1'
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ allprojects {
     apply plugin: 'maven'
 
     group = 'eu.optique-project'
-    version = '0.6.1'
+    version = '0.7.0'
 }
 
 subprojects {

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>eu.optique-project</groupId>
     <artifactId>r2rml-api-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.7-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <name>Optique R2RML API</name>
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>eu.optique-project</groupId>
     <artifactId>r2rml-api-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.7-SNAPSHOT</version>
     <name>Optique R2RML API</name>
     <licenses>
         <license>

--- a/r2rml-api-core/src/main/java/eu/optique/r2rml/api/MappingFactory.java
+++ b/r2rml-api-core/src/main/java/eu/optique/r2rml/api/MappingFactory.java
@@ -1,18 +1,6 @@
 package eu.optique.r2rml.api;
 
-import eu.optique.r2rml.api.model.GraphMap;
-import eu.optique.r2rml.api.model.InverseExpression;
-import eu.optique.r2rml.api.model.Join;
-import eu.optique.r2rml.api.model.LogicalTable;
-import eu.optique.r2rml.api.model.ObjectMap;
-import eu.optique.r2rml.api.model.PredicateMap;
-import eu.optique.r2rml.api.model.PredicateObjectMap;
-import eu.optique.r2rml.api.model.R2RMLView;
-import eu.optique.r2rml.api.model.RefObjectMap;
-import eu.optique.r2rml.api.model.SQLBaseTableOrView;
-import eu.optique.r2rml.api.model.SubjectMap;
-import eu.optique.r2rml.api.model.Template;
-import eu.optique.r2rml.api.model.TriplesMap;
+import eu.optique.r2rml.api.model.*;
 import org.apache.commons.rdf.api.BlankNodeOrIRI;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDFTerm;
@@ -173,6 +161,19 @@ public interface MappingFactory {
     SubjectMap createSubjectMap(IRI constant);
 
     /**
+     * Create a new SubjectMap containing an embedded triple, the embedded
+     * triple consists of three embedded term maps which are passed to the
+     * constructor. The term map type of the SubjectMap will be set to
+     * TermMapType.RDF_STAR_VALUED.
+     *
+     * @param subject The embedded subject.
+     * @param predicate The embedded predicate.
+     * @param object The embedded object.
+     * @return The created SubjectMap.
+     */
+    SubjectMap createSubjectMap(ObjectMap subject, PredicateMap predicate, ObjectMap object);
+
+    /**
      * Create a new PredicateMap with the given template. The term map type of
      * the PredicateMap will be set to TermMapType.TEMPLATE_VALUED.
      *
@@ -227,6 +228,19 @@ public interface MappingFactory {
      * @return The created ObjectMap.
      */
     ObjectMap createObjectMap(RDFTerm constant);
+
+    /**
+     * Create a new ObjectMap containing an embedded triple, the embedded
+     * triple consists of three embedded term maps which are passed to the
+     * constructor. The term map type of the SubjectMap will be set to
+     * TermMapType.RDF_STAR_VALUED.
+     *
+     * @param subject The embedded subject.
+     * @param predicate The embedded predicate.
+     * @param object The embedded object.
+     * @return The created ObjectMap.
+     */
+    ObjectMap createObjectMap(ObjectMap subject, PredicateMap predicate, ObjectMap object);
 
     /**
      * Create a new RefObjectMap with the given resource for the parent triples

--- a/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/RDFStarTermMap.java
+++ b/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/RDFStarTermMap.java
@@ -1,0 +1,16 @@
+package eu.optique.r2rml.api.model;
+
+
+/**
+ * RDF-star Term Map, essentially a wrapper around three other TermMaps
+ *
+ * @author Lukas Sundqvist
+ */
+public interface RDFStarTermMap extends TermMap {
+
+    ObjectMap getSubject();
+
+    PredicateMap getPredicate();
+
+    ObjectMap getObject();
+}

--- a/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/RDFStarVocabulary.java
+++ b/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/RDFStarVocabulary.java
@@ -7,7 +7,7 @@ package eu.optique.r2rml.api.model;
  */
 public class RDFStarVocabulary {
 
-    public static final String NAMESPACE = "https://w3id.org/obda/r2rmlstar/termmap#";
+    public static final String NAMESPACE = "https://w3id.org/obda/r2rmlstar#";
 
     public static final String PROP_STAR_SUBJECT = NAMESPACE + "subject";
     public static final String PROP_STAR_PREDICATE = NAMESPACE + "predicate";

--- a/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/RDFStarVocabulary.java
+++ b/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/RDFStarVocabulary.java
@@ -1,22 +1,3 @@
-/*******************************************************************************
- * Copyright 2013, the Optique Consortium
- *
- * Licensed under the Apache License, Version 2.0 (the "License";
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * This first version of the R2RML API was developed jointly at the University of Oslo,
- * the University of Bolzano, La Sapienza University of Rome, and fluid Operations AG,
- * as part of the Optique project, www.optique-project.eu
- ******************************************************************************/
 package eu.optique.r2rml.api.model;
 
 /**

--- a/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/RDFStarVocabulary.java
+++ b/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/RDFStarVocabulary.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright 2013, the Optique Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This first version of the R2RML API was developed jointly at the University of Oslo,
+ * the University of Bolzano, La Sapienza University of Rome, and fluid Operations AG,
+ * as part of the Optique project, www.optique-project.eu
+ ******************************************************************************/
+package eu.optique.r2rml.api.model;
+
+/**
+ * Vocabulary/String definitions for Ontop's unofficial RDF-star extension to R2RML
+ *
+ * @author Lukas Sundqvist
+ */
+public class RDFStarVocabulary {
+
+    public static final String NAMESPACE = "http://ontop-vkg.org/2021/rdfstar#";
+
+    public static final String PROP_STAR_SUBJECT = NAMESPACE + "subject";
+    public static final String PROP_STAR_PREDICATE = NAMESPACE + "predicate";
+    public static final String PROP_STAR_OBJECT = NAMESPACE + "object";
+
+    public static final String TERM_STAR_TRIPLE = NAMESPACE + "RDFStarTermType";
+}

--- a/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/RDFStarVocabulary.java
+++ b/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/RDFStarVocabulary.java
@@ -7,7 +7,7 @@ package eu.optique.r2rml.api.model;
  */
 public class RDFStarVocabulary {
 
-    public static final String NAMESPACE = "http://ontop-vkg.org/2021/rdfstar#";
+    public static final String NAMESPACE = "https://w3id.org/obda/r2rmlstar/termmap#";
 
     public static final String PROP_STAR_SUBJECT = NAMESPACE + "subject";
     public static final String PROP_STAR_PREDICATE = NAMESPACE + "predicate";

--- a/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/TermMap.java
+++ b/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/TermMap.java
@@ -36,7 +36,7 @@ public interface TermMap extends MappingComponent {
      * The term map must be set to one of these values when created.
      */
     public enum TermMapType {
-        CONSTANT_VALUED, TEMPLATE_VALUED, COLUMN_VALUED
+        CONSTANT_VALUED, TEMPLATE_VALUED, COLUMN_VALUED, RDF_STAR_VALUED
     }
 
 

--- a/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/impl/MappingFactoryImpl.java
+++ b/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/impl/MappingFactoryImpl.java
@@ -130,6 +130,11 @@ public class MappingFactoryImpl implements MappingFactory {
     }
 
     @Override
+	public SubjectMap createSubjectMap(ObjectMap subject, PredicateMap predicate, ObjectMap object) {
+		return new RDFStarSubjectMapImpl(rdf, subject, predicate, object);
+	}
+
+	@Override
 	public PredicateMap createPredicateMap(Template template) {
 		return new PredicateMapImpl(rdf, template);
 	}
@@ -158,7 +163,12 @@ public class MappingFactoryImpl implements MappingFactory {
     public ObjectMap createObjectMap(RDFTerm constant) {
         return new ObjectMapImpl(rdf, constant);
     }
-	
+
+	@Override
+	public ObjectMap createObjectMap(ObjectMap subject, PredicateMap predicate, ObjectMap object) {
+		return new RDFStarObjectMapImpl(rdf, subject, predicate, object);
+	}
+
 	public RefObjectMap createRefObjectMap(TriplesMap parentMap) {
 		return new RefObjectMapImpl(rdf, parentMap);
 	}

--- a/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/impl/R2RMLMappingCollectionImpl.java
+++ b/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/impl/R2RMLMappingCollectionImpl.java
@@ -555,8 +555,8 @@ public class R2RMLMappingCollectionImpl implements R2RMLMappingCollection {
 		// look for RDF-star triple
 		if (resource == null) {
 			resource = readObjectInMappingGraph(node, getRDF().createIRI(R2RMLVocabulary.PROP_TERM_TYPE));
-			if (resource != null && resource.toString().equals(RDFStarVocabulary.TERM_STAR_TRIPLE)) {
-				termMapType = TermMap.TermMapType.RDF_STAR_VALUED; }
+			if ((resource instanceof IRI) && resource.toString().equals(RDFStarVocabulary.TERM_STAR_TRIPLE)) {
+				termMapType = TermMap.TermMapType.RDF_STAR_VALUED; }	// TODO: Change comparison
 			else {
 				resource = null; }
 		}
@@ -642,8 +642,10 @@ public class R2RMLMappingCollectionImpl implements R2RMLMappingCollection {
 				return readTermMap((BlankNodeOrIRI) resource, getRDF().createIRI(R2RMLVocabulary.PROP_PREDICATE_MAP));
 			case "object":
 				resource = readObjectInMappingGraph(node, getRDF().createIRI(RDFStarVocabulary.PROP_STAR_OBJECT));
-				return readTermMap((BlankNodeOrIRI) resource, getRDF().createIRI(R2RMLVocabulary.PROP_OBJECT_MAP));}
-		return null;
+				return readTermMap((BlankNodeOrIRI) resource, getRDF().createIRI(R2RMLVocabulary.PROP_OBJECT_MAP));
+			default:
+				return null;
+		}
 	}
 
 	/**

--- a/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/impl/RDFStarObjectMapImpl.java
+++ b/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/impl/RDFStarObjectMapImpl.java
@@ -1,0 +1,109 @@
+package eu.optique.r2rml.api.model.impl;
+
+import eu.optique.r2rml.api.model.ObjectMap;
+import eu.optique.r2rml.api.model.PredicateMap;
+import eu.optique.r2rml.api.model.R2RMLVocabulary;
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.RDF;
+import org.apache.commons.rdf.api.Triple;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * An implementation of an ObjectMap containing an embedded triple.
+ *
+ * @author Marius Strandhaug
+ * @author Lukas Sundqvist
+ */
+public class RDFStarObjectMapImpl extends RDFStarTermMapImpl implements ObjectMap {
+
+    RDFStarObjectMapImpl(RDF rdf, ObjectMap subject, PredicateMap predicate, ObjectMap object) {
+        super(rdf, subject, predicate, object);
+    }
+
+    @Override
+    public void setLanguageTag(String lang) {
+        throw new IllegalStateException("The TermMapType is " + this.termMapType +
+                ", which does not support language tags.");
+    }
+
+    @Override
+    public void setDatatype(IRI datatypeURI) {
+        throw new IllegalStateException("The TermMapType is " + this.termMapType +
+                ", which does not support data types.");
+    }
+
+    @Override
+    public String getLanguageTag() {
+        return null;
+    }
+
+    @Override
+    public IRI getDatatype() {
+        return null;
+    }
+
+    @Override
+    public void removeDatatype() {
+
+    }
+
+    @Override
+    public void removeLanguageTag() {
+
+    }
+
+    @Override
+    public Set<Triple> serialize() {
+        Set<Triple> stmtSet = new HashSet<>();
+
+        stmtSet.addAll(super.serialize());
+
+        stmtSet.add(getRDF().createTriple(getNode(),
+                getRDF().createIRI("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+                getRDF().createIRI(R2RMLVocabulary.TYPE_OBJECT_MAP)));
+
+        stmtSet.addAll(subject.serialize());
+        stmtSet.addAll(predicate.serialize());
+        stmtSet.addAll(object.serialize());
+
+        return stmtSet;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((subject == null) ? 0 : subject.hashCode());
+        result = prime * result + ((predicate == null) ? 0 : predicate.hashCode());
+        result = prime * result + ((object == null) ? 0 : object.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+
+        if (!super.equals(obj))
+            return false;
+
+        if (!(obj instanceof RDFStarObjectMapImpl))
+            return false;
+
+        RDFStarObjectMapImpl other = (RDFStarObjectMapImpl) obj;
+        if (!subject.equals(other.subject) || !predicate.equals(other.predicate) || !object.equals(other.object)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "RDFStarObjectMapImpl [termMapType=" + termMapType + ", termTypeIRI="+ termTypeIRI +
+                ", node=" + getNode() + "subject=(" + subject.toString() + "), predicate=(" +
+                predicate.toString() + "), object=(" + object.toString() + ")] ";
+    }
+}

--- a/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/impl/RDFStarObjectMapImpl.java
+++ b/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/impl/RDFStarObjectMapImpl.java
@@ -13,7 +13,6 @@ import java.util.Set;
 /**
  * An implementation of an ObjectMap containing an embedded triple.
  *
- * @author Marius Strandhaug
  * @author Lukas Sundqvist
  */
 public class RDFStarObjectMapImpl extends RDFStarTermMapImpl implements ObjectMap {

--- a/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/impl/RDFStarSubjectMapImpl.java
+++ b/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/impl/RDFStarSubjectMapImpl.java
@@ -1,0 +1,143 @@
+package eu.optique.r2rml.api.model.impl;
+
+import eu.optique.r2rml.api.model.*;
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.RDF;
+import org.apache.commons.rdf.api.Triple;
+
+import java.util.*;
+
+/**
+ * An implementation of a SubjectMap containing an embedded triple.
+ *
+ * @author Marius Strandhaug
+ * @author Lukas Sundqvist
+ */
+public class RDFStarSubjectMapImpl extends RDFStarTermMapImpl implements SubjectMap {
+
+    private ArrayList<IRI> classList;
+
+    private ArrayList<GraphMap> graphList;
+
+    RDFStarSubjectMapImpl(RDF c, ObjectMap subject, PredicateMap predicate, ObjectMap object) {
+        super(c, subject, predicate, object);
+        
+        classList = new ArrayList<>();
+        graphList = new ArrayList<>();
+    }
+
+    @Override
+    public void addClass(IRI classURI) {
+        classList.add(classURI);
+    }
+
+    @Override
+    public void addGraphMap(GraphMap gm) {
+        graphList.add(gm);
+    }
+
+    @Override
+    public void addGraphMap(List<GraphMap> gms) {
+        graphList.addAll(gms);
+    }
+
+    @Override
+    public IRI getClass(int index) {
+        return classList.get(index);
+    }
+
+    @Override
+    public GraphMap getGraphMap(int index) {
+        return graphList.get(index);
+    }
+
+    @Override
+    public List<IRI> getClasses() {
+        return Collections.unmodifiableList(classList);
+    }
+
+    @Override
+    public List<GraphMap> getGraphMaps() {
+        return Collections.unmodifiableList(graphList);
+    }
+
+    @Override
+    public void removeClass(IRI classURI) {
+        classList.remove(classURI);
+    }
+
+    @Override
+    public void removeGraphMap(GraphMap gm) {
+        graphList.remove(gm);
+    }
+
+    @Override
+    public Set<Triple> serialize() {
+        Set<Triple> stmtSet = new HashSet<Triple>();
+
+        stmtSet.addAll(super.serialize());
+
+        stmtSet.add(getRDF().createTriple(getNode(), getRDF().createIRI("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"), getRDF().createIRI(R2RMLVocabulary.TYPE_SUBJECT_MAP)));
+
+
+        for (IRI cl : classList) {
+            stmtSet.add(getRDF().createTriple(getNode(), getRDF().createIRI(R2RMLVocabulary.PROP_CLASS), cl));
+        }
+
+        for(GraphMap g : graphList){
+            if(g.getTermMapType() == TermMap.TermMapType.CONSTANT_VALUED){
+                // Use constant shortcut property.
+                stmtSet.add(getRDF().createTriple(getNode(), getRDF().createIRI(R2RMLVocabulary.PROP_GRAPH), g.getConstant()));
+            }else{
+                stmtSet.add(getRDF().createTriple(getNode(), getRDF().createIRI(R2RMLVocabulary.PROP_GRAPH_MAP), g.getNode()));
+                stmtSet.addAll(g.serialize());
+            }
+        }
+
+        stmtSet.addAll(subject.serialize());
+        stmtSet.addAll(predicate.serialize());
+        stmtSet.addAll(object.serialize());
+
+        return stmtSet;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ((classList == null) ? 0 : classList.hashCode());
+        result = prime * result + ((subject == null) ? 0 : subject.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+
+        if (!super.equals(obj))
+            return false;
+
+        if (!(obj instanceof RDFStarSubjectMapImpl))
+            return false;
+
+        RDFStarSubjectMapImpl other = (RDFStarSubjectMapImpl) obj;
+        if (classList == null) {
+            if (other.classList != null) {
+                return false;
+            }
+        } else if (!classList.equals(other.classList) || !subject.equals(other.subject) || !predicate.equals(other.predicate) || !object.equals(other.object)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "RDFStarSubjectMapImpl [classList=" + classList + ", graphList=" +
+                graphList + ", termMapType=" + termMapType + ", termTypeIRI="+ termTypeIRI +
+                ", node=" + getNode() + "subject=(" + subject.toString() + "), predicate=(" +
+                predicate.toString() + "), object=(" + object.toString() + ")] ";
+    }
+
+}

--- a/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/impl/RDFStarSubjectMapImpl.java
+++ b/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/impl/RDFStarSubjectMapImpl.java
@@ -10,7 +10,6 @@ import java.util.*;
 /**
  * An implementation of a SubjectMap containing an embedded triple.
  *
- * @author Marius Strandhaug
  * @author Lukas Sundqvist
  */
 public class RDFStarSubjectMapImpl extends RDFStarTermMapImpl implements SubjectMap {

--- a/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/impl/RDFStarTermMapImpl.java
+++ b/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/impl/RDFStarTermMapImpl.java
@@ -1,0 +1,51 @@
+package eu.optique.r2rml.api.model.impl;
+
+import eu.optique.r2rml.api.model.*;
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.RDF;
+
+import java.util.Collections;
+import java.util.List;
+
+public abstract class RDFStarTermMapImpl extends TermMapImpl implements RDFStarTermMap {
+
+    private List<IRI> validTermTypes = Collections.singletonList(
+            getRDF().createIRI(RDFStarVocabulary.TERM_STAR_TRIPLE));
+
+    ObjectMap subject;
+    PredicateMap predicate;
+    ObjectMap object;
+
+    RDFStarTermMapImpl(RDF rdf, ObjectMap subject, PredicateMap predicate, ObjectMap object) {
+        super(rdf);
+        this.subject = subject;
+        this.predicate = predicate;
+        this.object = object;
+    }
+
+    @Override
+    public ObjectMap getSubject() {
+        return subject;
+    }
+
+    @Override
+    public PredicateMap getPredicate() {
+        return predicate;
+    }
+
+    @Override
+    public ObjectMap getObject() {
+        return object;
+    }
+
+    @Override
+    public void setDefaultTermType() {
+        termTypeIRI = getRDF().createIRI(RDFStarVocabulary.TERM_STAR_TRIPLE);
+    }
+
+
+    @Override
+    public List<IRI> getValidTermTypes() {
+        return validTermTypes;
+    }
+}

--- a/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/impl/TermMapImpl.java
+++ b/r2rml-api-core/src/main/java/eu/optique/r2rml/api/model/impl/TermMapImpl.java
@@ -86,6 +86,14 @@ public abstract class TermMapImpl extends MappingComponentImpl implements TermMa
         setNode(getRDF().createBlankNode());
     }
 
+    // Is only used by unofficial RDF-star extension
+    TermMapImpl(RDF rdf) {
+        super(rdf);
+        this.termMapType = TermMapType.RDF_STAR_VALUED;
+        this.termTypeIRI = null;
+        setNode(getRDF().createBlankNode());
+    }
+
 
     @Override
     public TermMapType getTermMapType() {
@@ -102,6 +110,7 @@ public abstract class TermMapImpl extends MappingComponentImpl implements TermMa
         switch (termMapType) {
             case TEMPLATE_VALUED:
             case COLUMN_VALUED:
+            case RDF_STAR_VALUED:
                 this.termTypeIRI = typeIRI;
                 break;
             case CONSTANT_VALUED:

--- a/r2rml-api-rdf4j-binding/src/test/java/rdf4jTest/RDFStar_Test.java
+++ b/r2rml-api-rdf4j-binding/src/test/java/rdf4jTest/RDFStar_Test.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright 2013, the Optique Consortium
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * This first version of the R2RML API was developed jointly at the University of Oslo, 
+ * the University of Bolzano, La Sapienza University of Rome, and fluid Operations AG, 
+ * as part of the Optique project, www.optique-project.eu
+ ******************************************************************************/
+package rdf4jTest;
+
+import eu.optique.r2rml.api.binding.rdf4j.RDF4JR2RMLMappingManager;
+import eu.optique.r2rml.api.model.*;
+import eu.optique.r2rml.api.model.impl.SQLBaseTableOrViewImpl;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.helpers.StatementCollector;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * JUnit Test Cases for RDFStar support
+ * 
+ * @author Riccardo Mancini
+ * @author Lukas Sundqvist
+ */
+public class RDFStar_Test
+{
+	
+	@Test
+	public void test1() throws Exception{
+		
+		InputStream fis = getClass().getResourceAsStream("../mappingFiles/prof-rdfstar.ttl");
+		
+		RDF4JR2RMLMappingManager mm = RDF4JR2RMLMappingManager.getInstance();
+		
+		// Read the file into a model.
+		RDFParser rdfParser = Rio.createParser(RDFFormat.TURTLE);
+		Model m = new LinkedHashModel();
+		rdfParser.setRDFHandler(new StatementCollector(m));
+		rdfParser.parse(fis, "testMapping");
+		
+		Collection<TriplesMap> coll = mm.importMappings(m);
+		
+		Assert.assertTrue(coll.size()==2);
+		
+		Iterator<TriplesMap> it=coll.iterator();
+		/*while(it.hasNext()){
+			TriplesMap current=it.next();
+
+			SubjectMap s=current.getSubjectMap();
+			Template t=s.getTemplate();
+			Assert.assertTrue(t.getColumnName(0).contains("EMPNO"));
+			
+			LogicalTable table=current.getLogicalTable();
+			
+			SQLBaseTableOrViewImpl ta= (SQLBaseTableOrViewImpl) table;
+			Assert.assertTrue(ta.getTableName().contains("EMP2DEPT"));
+				
+		}*/
+	}
+	
+	
+
+	
+	
+	@Test
+	@Ignore
+	public void test2() throws Exception{
+		
+		InputStream fis = getClass().getResourceAsStream("../mappingFiles/test5.ttl");
+		
+		RDF4JR2RMLMappingManager mm = RDF4JR2RMLMappingManager.getInstance();
+		
+		// Read the file into a model.
+		RDFParser rdfParser = Rio.createParser(RDFFormat.TURTLE);
+		Model m = new LinkedHashModel();
+		rdfParser.setRDFHandler(new StatementCollector(m));
+		rdfParser.parse(fis, "testMapping");
+		
+		Collection<TriplesMap> coll = mm.importMappings(m);
+		
+		Assert.assertTrue(coll.size()==1);
+		
+		Iterator<TriplesMap> it=coll.iterator();
+		while(it.hasNext()){
+			TriplesMap current=it.next();
+
+			Iterator<PredicateObjectMap> pomit=current.getPredicateObjectMaps().iterator();
+			PredicateObjectMap pom=pomit.next();
+			
+			Iterator<PredicateMap> pmit=pom.getPredicateMaps().iterator();
+			while(pmit.hasNext()){
+				PredicateMap p=pmit.next();
+				boolean first=p.getConstant().toString().contains("department");
+				
+				Assert.assertTrue(first);
+				
+			}
+			
+			Iterator<ObjectMap> omit=pom.getObjectMaps().iterator();
+			while(omit.hasNext()){
+				ObjectMap o=omit.next();
+				
+				boolean first=o.getTemplate().getColumnName(0).contains("DEPTNO");
+				
+				Assert.assertTrue(first);
+
+			}
+		}
+	}
+
+	
+}

--- a/r2rml-api-rdf4j-binding/src/test/java/rdf4jTest/RDFStar_Test.java
+++ b/r2rml-api-rdf4j-binding/src/test/java/rdf4jTest/RDFStar_Test.java
@@ -58,74 +58,13 @@ public class RDFStar_Test
 		rdfParser.parse(fis, "testMapping");
 		
 		Collection<TriplesMap> coll = mm.importMappings(m);
-		
-		Assert.assertTrue(coll.size()==2);
-		
-		Iterator<TriplesMap> it=coll.iterator();
-		/*while(it.hasNext()){
-			TriplesMap current=it.next();
 
-			SubjectMap s=current.getSubjectMap();
-			Template t=s.getTemplate();
-			Assert.assertTrue(t.getColumnName(0).contains("EMPNO"));
-			
-			LogicalTable table=current.getLogicalTable();
-			
-			SQLBaseTableOrViewImpl ta= (SQLBaseTableOrViewImpl) table;
-			Assert.assertTrue(ta.getTableName().contains("EMP2DEPT"));
-				
-		}*/
+		Assert.assertEquals(2, coll.size());
+		Assert.assertTrue(coll.stream()
+				.anyMatch(triplesMap -> triplesMap.getSubjectMap() instanceof RDFStarTermMap));
+		Assert.assertTrue(coll.stream()
+				.flatMap(triplesMap -> triplesMap.getPredicateObjectMaps().stream()
+						.flatMap(predicateObjectMap -> predicateObjectMap.getObjectMaps().stream()))
+				.anyMatch(objectMap -> objectMap instanceof RDFStarTermMap));
 	}
-	
-	
-
-	
-	
-	@Test
-	@Ignore
-	public void test2() throws Exception{
-		
-		InputStream fis = getClass().getResourceAsStream("../mappingFiles/test5.ttl");
-		
-		RDF4JR2RMLMappingManager mm = RDF4JR2RMLMappingManager.getInstance();
-		
-		// Read the file into a model.
-		RDFParser rdfParser = Rio.createParser(RDFFormat.TURTLE);
-		Model m = new LinkedHashModel();
-		rdfParser.setRDFHandler(new StatementCollector(m));
-		rdfParser.parse(fis, "testMapping");
-		
-		Collection<TriplesMap> coll = mm.importMappings(m);
-		
-		Assert.assertTrue(coll.size()==1);
-		
-		Iterator<TriplesMap> it=coll.iterator();
-		while(it.hasNext()){
-			TriplesMap current=it.next();
-
-			Iterator<PredicateObjectMap> pomit=current.getPredicateObjectMaps().iterator();
-			PredicateObjectMap pom=pomit.next();
-			
-			Iterator<PredicateMap> pmit=pom.getPredicateMaps().iterator();
-			while(pmit.hasNext()){
-				PredicateMap p=pmit.next();
-				boolean first=p.getConstant().toString().contains("department");
-				
-				Assert.assertTrue(first);
-				
-			}
-			
-			Iterator<ObjectMap> omit=pom.getObjectMaps().iterator();
-			while(omit.hasNext()){
-				ObjectMap o=omit.next();
-				
-				boolean first=o.getTemplate().getColumnName(0).contains("DEPTNO");
-				
-				Assert.assertTrue(first);
-
-			}
-		}
-	}
-
-	
 }

--- a/r2rml-api-rdf4j-binding/src/test/java/rdf4jTest/RDFStar_Test.java
+++ b/r2rml-api-rdf4j-binding/src/test/java/rdf4jTest/RDFStar_Test.java
@@ -1,21 +1,3 @@
-/*******************************************************************************
- * Copyright 2013, the Optique Consortium
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
- * This first version of the R2RML API was developed jointly at the University of Oslo, 
- * the University of Bolzano, La Sapienza University of Rome, and fluid Operations AG, 
- * as part of the Optique project, www.optique-project.eu
- ******************************************************************************/
 package rdf4jTest;
 
 import eu.optique.r2rml.api.binding.rdf4j.RDF4JR2RMLMappingManager;
@@ -38,7 +20,6 @@ import java.util.Iterator;
 /**
  * JUnit Test Cases for RDFStar support
  * 
- * @author Riccardo Mancini
  * @author Lukas Sundqvist
  */
 public class RDFStar_Test

--- a/r2rml-api-rdf4j-binding/src/test/resources/mappingFiles/prof-rdfstar.ttl
+++ b/r2rml-api-rdf4j-binding/src/test/resources/mappingFiles/prof-rdfstar.ttl
@@ -3,7 +3,7 @@
 @prefix rr: <http://www.w3.org/ns/r2rml#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-@prefix star: <http://ontop-vkg.org/2021/rdfstar#>.
+@prefix star: <https://w3id.org/obda/r2rmlstar#>.
 @prefix ex: <http://example.org/>.
 
 <urn:MAPID-professor-certainty> a rr:TriplesMap;

--- a/r2rml-api-rdf4j-binding/src/test/resources/mappingFiles/prof-rdfstar.ttl
+++ b/r2rml-api-rdf4j-binding/src/test/resources/mappingFiles/prof-rdfstar.ttl
@@ -1,0 +1,55 @@
+@prefix : <http://www.semanticweb.org/user/ontologies/2016/8/untitled-ontology-84#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix star: <http://ontop-vkg.org/2021/rdfstar#>.
+@prefix ex: <http://example.org/>.
+
+<urn:MAPID-professor-certainty> a rr:TriplesMap;
+  rr:logicalTable [ a rr:R2RMLView;
+      rr:sqlQuery "SELECT prof_id FROM professors;"
+    ];
+  rr:subjectMap [ a rr:SubjectMap;
+      rr:termType star:RDFStarTermType;
+      star:subject [a rr:ObjectMap;
+        rr:template "http://www.semanticweb.org/user/ontologies/2016/8/untitled-ontology-84#individuals/professor_{prof_id}";
+        ];
+      star:predicate [a rr:PredicateMap;
+        rr:constant rdf:type
+        ];
+      star:object [a rr:ObjectMap;
+        rr:constant :Professor
+        ];
+      rr:class :RDFStarTriple;
+    ];
+  rr:predicateObjectMap [
+      rr:predicate :source;
+      rr:object "My First Database";
+    ].
+
+<urn:MAPID-professor-mentioned> a rr:TriplesMap;
+  rr:logicalTable [ a rr:R2RMLView;
+      rr:sqlQuery "SELECT prof_id, last_name FROM professors;"
+    ];
+  rr:subjectMap [ a rr:SubjectMap;
+      rr:template "http://www.semanticweb.org/user/ontologies/2016/8/untitled-ontology-84#individuals/professor_{prof_id}";
+      rr:class :Professor;
+    ];
+  rr:predicateObjectMap [
+      rr:predicate :isMentionedBy;
+      rr:objectMap [  a rr:ObjectMap;
+        rr:termType star:RDFStarTermType;
+        star:subject [a rr:ObjectMap;
+            rr:template "http://www.semanticweb.org/user/ontologies/2016/8/untitled-ontology-84#individuals/professor_{prof_id}";
+            rr:termType rr:IRI;
+          ];
+        star:predicate [a rr:PredicateMap;
+            rr:constant :hasLastname;
+          ];
+        star:object [a rr:ObjectMap;
+            rr:column "last_name";
+            rr:termType rr:Literal;
+          ];
+        ];
+    ].


### PR DESCRIPTION
@ghxiao This code was produced as part of my thesis work at the university, with professor Calvanese as supervisor and Benjamin Cogrel as support from ontopic's side. Care has been taken to not change the functionality at all except as it relates to the thesis and Ontop's upcoming RDF-star support.